### PR TITLE
Correct default landing page

### DIFF
--- a/docs/asset_info.md
+++ b/docs/asset_info.md
@@ -1,7 +1,6 @@
 ---
 id: asset_info
 title: Asset Information API
-slug: /
 ---
 
 ## Purpose

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 id: index
 title: Introduction
-
+slug: /
 ---
 
 As we continue to build on the number of APIs currently in service we provide a central repository for all of the specificactions that have been agreed.  The Swagger documentation provides a concise view of the various endpoints of our APIs and how to use them.  Our API specifications document our journey to establishing how the APIs were designed and the many decisions that were taken.  This will give us the opportunity to learn from our past choices and continue to build and improve as we go.


### PR DESCRIPTION
## What
Changed the default landing page from the asset information page to the main index page

## Why
The main index page should be the first page seen when arriving at the api specs pages