### PR TITLE
mttl-755 - Equality Information API Spec

### DIFF
--- a/docs/equality-information-api.md
+++ b/docs/equality-information-api.md
@@ -60,32 +60,32 @@ In the second workshop, we discussed the necessity of the equalities information
 
 ### Endpoints to be created for the equality information microservice
 
-Note: equality-information-id should be equal to person-id
-
 1. GET **/equality-information/{equality-information-id}**
-2. PATCH **/equality-information/{equality-information-id}**
-3. POST **/equality-information/{equality-information-id}**
+2. GET **/equality-information/{target-id}**
+3. PATCH **/equality-information/{equality-information-id}**
+4. POST **/equality-information/{equality-information-id}**
 
 **Example payload**
 ```
 {
-    "id": "",
+    "id": "45b919fa-22b4-11ec-9621-0242ac130002",
+    "targetId": "49b092d6-22b4-11ec-9621-0242ac130002",
     "gender": {
-      "genderValue": "M",
+      "genderValue": "m",
       "genderValueIfOther": "",
       "genderDifferentToBirthSex": True
     },
-    "nationality": "British",
+    "nationality": "british",
     "ethnicity": {
-      "ethnicGroupValue": "White",
+      "ethnicGroupValue": "white",
       "ethnicGroupValueIfOther": ""
     },
     "religionOrBelief": {
-      "religionOrBeliefValue": "Christian",
+      "religionOrBeliefValue": "christian",
       "religionOrBeliefValueIfOther": ""
     },
     "sexualOrientation": {
-      "sexualOrientationValue": "Heterosexual",
+      "sexualOrientationValue": "heterosexual",
       "sexualOrientationValueIfOther": ""
     },
     "marriageOrCivilPartnership": {
@@ -94,24 +94,24 @@ Note: equality-information-id should be equal to person-id
     },
     "pregnancyOrMaternity": [
       {
-        "datePregnancy": "2017-01-04", -- date entered by the user
-        "pregnancyRecordValidUntil": "2019-10-04" -- datePregnancy + 2 years and 9 months
+        "pregnancyDate": "2017-01-04", -- date entered by the user
+        "pregnancyValidUntil": "2019-10-04" -- datePregnancy + 2 years and 9 months
       }
     ],
     "nationalInsuranceNumber": "NI111111A",
     "languages": [
         {
-            "language": "French",
+            "language": "french",
             "isPrimary": false
         },
         {
-            "language": "English",
+            "language": "english",
             "isPrimary": true
         }
     ],
     "caringResponsibilities": {
       "provideUnpaidCare": True,
-      "hoursSpentProvidingUnpaidCare": "5 to 9 hours"
+      "hoursSpentProvidingUnpaidCare": "fiveToNineHours"
     },
     "disabled": True,
     "communicationRequirements": [
@@ -119,11 +119,20 @@ Note: equality-information-id should be equal to person-id
         "interpreterNeeded",
         "largePrint"
     ],
-    "economicSituation": "Employed full time",
-    "homeSituation": "Temporary accommodation (placed by Hackney Council)",
-    "armedForces": "A serving member of the armed forces"
+    "economicSituation": "employedFullTime",
+    "homeSituation": "temporaryAccommodationPlacedByHackneyCouncil",
+    "armedForces": "aServingMemberOfTheArmedForces"
 }
 ```
 
-### Architecture Diagram
-![Platform API vs Service API comparison](./doc-images/person_api_arch_diagram.png)
+The following fields will store codes that come from the reference data:
+* genderValue
+* nationality
+* ethnicGroupValue
+* religionOrBeliefValue
+* sexualOrientationValue
+* language
+* hoursSpentProvidingUnpaidCare
+* economicSituation
+* homeSituation
+* armedForces

--- a/docs/equality-information-api.md
+++ b/docs/equality-information-api.md
@@ -1,0 +1,129 @@
+---
+id: equality-information-api
+title: Equality Information API
+---
+
+## Purpose
+To identify all information to be captured with regards to the equality information domain related to a person.
+
+This will be the core platform API to be used by other areas within the housing domain for the current needs, however with the scope of extending this to other datasets. With no Citizens Index in place due to the cyber-attack, we will be posed with the question of a single view of all resident information and their interactions with the council. Also, it will enable Hackney to handle fairly all residents requests based on this data.
+
+As part of our solution we are proposing for a housing stream to develop the first version of this service as a pilot. This will help to target services more effectively, achieve better outcomes and enhance performance monitoring while reducing cost and risk. This means that we can offer a deeper, more citizen-centric self-service capability, enabling even more service transactions to be carried out online.
+
+Having a single equality information domain related to a person domain will enable us to remove the silos mechanism for resident information collection and help us to present extended and needed resident information. Also, it will help the contact centre and officers in better and informed decision making for managing the ongoing service demands.
+
+## Vision
+- A single, centralized data source, holding all equality information data about people, updated by multiple services.
+- A reusable microservice API used for managing that data.
+- Single data source to help us achieve consistency in data structure related to person’s equality information data and remove duplication of resident data we hold.
+- Reducing development efforts
+- Flexibility to store ‘extended’ data, related to a person, that might be sensitive and only accessible by a single service area
+- Remove the need for the difficult task of data matching in the future (where multiple records of the same person across systems need to be matched) as all data will be saved in the same location with the same ID across person and equality information.
+
+## Our users and their needs
+
+** As a service user I would like to see the resident equalities information so that: **
+- I can make an informed decision with regards to the resident query I am dealing with.
+- I have the extended information about the council tenant.
+- I can perform my tasks - creating tenure management processes, make informed decisions about tenures and more
+
+** As a service user, I would like: **
+- View and update existing equalities records of people
+- An easy way to find out information about a person so that I don’t have to search multiple systems in order to find details about the same person recorded by separate systems
+
+** As a consumer of this API I would like to see: **
+- The name of the person so that this data is available for any housing service (at present) that requires it.
+- The nationality of the person so that this data is available to any service that requires it.
+- The gender of the person so that this data is available for any service that requires it.
+- The ethnic origin of the person, so that I have this data available for any service that requires it.
+- The title of the person, so that I have this data available for any service that requires it.
+- The DOB of the person so that I have this data available for any service that requires it.
+
+** As a developer, I want to: **
+- build and reuse a single Equalities Information API microservice so that development efforts can be focused on other requirements
+- Ensure data updated, retrieved and inserted is consistent across services and reliable
+- Have an easy way to retrieve any equalities information data related to a person so that I don’t need to make additional calls to find references for related systems
+
+** As an application  support analyst **
+-  I need to understand the queries being used by the API so that I can deal with support requests accordingly and resolve the potential issues in the underlying data,
+
+** As a data analyst**
+-  I need to connect to the API via Qlik so that data is easy to interpret and available for further reporting purpose.and analysis.
+
+## Workshop outcome
+### Workshop 1 & 2
+
+**Summary**
+Our first workshop has been around getting a decision to remove the equalities information fields that we had in the person's API and data model, based on a recommendation from Information Management team.
+
+In the second workshop, we discussed the necessity of the equalities information microservice and the data that should be stored in managed by its API.
+
+### Endpoints to be created for the equality information microservice
+
+Note: equality-information-id should be equal to person-id
+
+1. GET **/equality-information/{equality-information-id}**
+2. PATCH **/equality-information/{equality-information-id}**
+3. POST **/equality-information/{equality-information-id}**
+
+**Example payload**
+```
+{
+    "id": "",
+    "gender": {
+      "genderValue": "M",
+      "genderValueIfOther": "",
+      "genderDifferentToBirthSex": True
+    },
+    "nationality": "British",
+    "ethnicity": {
+      "ethnicGroupValue": "White",
+      "ethnicGroupValueIfOther": ""
+    },
+    "religionOrBelief": {
+      "religionOrBeliefValue": "Christian",
+      "religionOrBeliefValueIfOther": ""
+    },
+    "sexualOrientation": {
+      "sexualOrientationValue": "Heterosexual",
+      "sexualOrientationValueIfOther": ""
+    },
+    "marriageOrCivilPartnership": {
+      "married": True,
+      "civilPartnership": True
+    },
+    "pregnancyOrMaternity": [
+      {
+        "datePregnancy": "2017-01-04", -- date entered by the user
+        "pregnancyRecordValidUntil": "2019-10-04" -- datePregnancy + 2 years and 9 months
+      }
+    ],
+    "nationalInsuranceNumber": "NI111111A",
+    "languages": [
+        {
+            "language": "French",
+            "isPrimary": false
+        },
+        {
+            "language": "English",
+            "isPrimary": true
+        }
+    ],
+    "caringResponsibilities": {
+      "provideUnpaidCare": True,
+      "hoursSpentProvidingUnpaidCare": "5 to 9 hours"
+    },
+    "disabled": True,
+    "communicationRequirements": [
+        "signLanguage",
+        "interpreterNeeded",
+        "largePrint"
+    ],
+    "economicSituation": "Employed full time",
+    "homeSituation": "Temporary accommodation (placed by Hackney Council)",
+    "armedForces": "A serving member of the armed forces"
+}
+```
+
+### Architecture Diagram
+![Platform API vs Service API comparison](./doc-images/person_api_arch_diagram.png)

--- a/docs/equality-information-api.md
+++ b/docs/equality-information-api.md
@@ -119,8 +119,14 @@ In the second workshop, we discussed the necessity of the equalities information
         "interpreterNeeded",
         "largePrint"
     ],
-    "economicSituation": "employedFullTime",
-    "homeSituation": "temporaryAccommodationPlacedByHackneyCouncil",
+    "economicSituation": {
+      "economicSituationValue": "employedFullTime",
+      "economicSituationValueIfOther": ""
+    },
+    "homeSituation": {
+      "homeSituationValue": "temporaryAccommodationPlacedByHackneyCouncil",
+      "homeSituationValueIfOther": ""
+    },
     "armedForces": "aServingMemberOfTheArmedForces"
 }
 ```

--- a/docs/person-api.md
+++ b/docs/person-api.md
@@ -115,52 +115,33 @@ HackIT proposal for Person data model based on the model proposed by Amido.
 {
     "id": "TWVoZGlLaW1ha2hlCg==",
     "title": "Mr",
-    "forename": "Mehdi",
-    "Preferred forename": "Mehdi",
-    "middle name": "",
+    "firstName": "Mehdi",
+    "middleName": "",
     "surname": "Kimakhe",
-    "Preferred surname": "Kimakhe",
-    "nationality": "Morrocan",
+    "preferredTitle": "Mr"
+    "preferredFirstName": "Mehdi",
+    "preferredMiddleName": "",
+    "preferredSurname": "Kimakhe",
     "place of birth": "Rabat",
     "date of birth": "1989-10-11",
-    "gender": "M",
-    "identification": [
-        {
-            "type": "NI",
-            "value": "1234A",
-            "Original Document Seen": false,
-            ‘Link to document’: ‘link’
-        },
-        {
-            "type": "passport",
-            "value": "A11111",
-            "Original Document Seen": true
-        }
+    "personTypes": [
+      "Tenant"
     ],
-    "languages": [
-        {
-            "language": "French",
-            "is primary": false
-        },
-        {
-            "language": "English",
-            "is primary": true
-        }
+    "tenures": [
+      {
+        "id": "6f22e9ae3e8a4e0eaf46db02eb87f8e6",
+        "type": "SECURE",
+        "startDate": "12/01/2021",
+        "endDate": "23/07/2021",
+        "assetFullAddress": "1 Hillman St, Hackney, E8 1DY",
+        "assetId": "6f22e9ae3e8a4e0eaf46db02eb87f8e6",
+        "uprn": "1234567890",
+        "isActive": false,
+        "paymentReference": "string",
+        "propertyReference": "string"
+      }
     ],
-    "communication": [
-        {
-            "channel": "email",
-            "value": "mehdi.kimakhe@hackney.gov.uk"
-        },
-        {
-            "channel": "phone",
-            "value": "07000000000"
-        }
-    ],
-    "communication requirements": [
-        "sign language",
-        "interpreter needed"
-    ],
+    "reason": "New tenant to Hackney's system",
 
     "links": [
             {


### PR DESCRIPTION
## What
* Removed equality fields and cleaned the person API payload to match swagger.
* Added API spec for equality information.

## Why
Part of Manage My Home requirements and to follow the equality information policy, we need to collect additional fields related to person to make sure officers make informed decisions. Therefore, there is a need for a microservice to handle this data.

## Link to ticket (Jira, Trello, Clickup, etc)
Jira: https://hackney.atlassian.net/browse/MTTL-755