### PR TITLE
MTTL-2936: Add staff search endpoint to Housing Search API

### DIFF
--- a/docs/housing_search.md
+++ b/docs/housing_search.md
@@ -33,7 +33,8 @@ Searching is achieved by providing `searchText` as a string parameter.
 1. Person - First name, Middle name, Last name
 2. Asset - Address line 1, Postcode, Asset type
 3. Tenure - Payment Reference, FullAddress of TenuredAsset , Household Members FullName  
-4. Transactions - Sender name, Transaction Type, Payment Reference, Bank Account Number, Transaction Date, Transaction Amount  
+4. Transactions - Sender name, Transaction Type, Payment Reference, Bank Account Number, Transaction Date, Transaction Amount
+5. Staff - first Name, last name, email
 
 ### Filtering
 
@@ -82,7 +83,8 @@ Allows to search on fields which do not exist only on platform APIs. It allows t
 6. High Scalable
 
 ** Dependencies : **
-- By person
+
+** By person **
 - Person Information
 - Tenure
 - Asset Information
@@ -98,6 +100,11 @@ Allows to search on fields which do not exist only on platform APIs. It allows t
 - Tenure
 - Person Information
 - Alert
+
+** By Staff **
+- Person Information
+- Contact Details
+- Patches & Areas
 
 ### Workshop 26/04/2022
 


### PR DESCRIPTION
## What
Add staff search endpoint to Housing Search API, as discussed in the data meetup.

## Why
This new endpoint will allow clients to view staff data by searching using their email - specifically their patch Id for MMH to use in upcoming worktray development.

## Link to ticket (Jira, Trello, Clickup, etc)

https://hackney.atlassian.net/browse/MTTL-2936
